### PR TITLE
fix(updater): correct updater executable name and improve exit process

### DIFF
--- a/dgupdater/cli_commands/init/func/create_configuration_files.py
+++ b/dgupdater/cli_commands/init/func/create_configuration_files.py
@@ -32,7 +32,7 @@ def create_configuration_files(data: dict, app_name: str, mongodbstrd: str) -> N
         dump(dgupdaterconf_json, f, indent = 4)
 
     with open('.dgupdaterignore', 'w') as f:
-        f.write('.dgupdaterignore\nupdate.exe')
+        f.write('.dgupdaterignore\ndgupdaterupdate.exe')
 
     with package_path("dgupdater") as bin_path:
         copyfile(join(bin_path, "bin", "dgupdaterupdate.exe"), "dgupdaterupdate.exe")

--- a/dgupdater/functions/check_update/check_update.py
+++ b/dgupdater/functions/check_update/check_update.py
@@ -1,5 +1,7 @@
 from subprocess import Popen, CREATE_NEW_CONSOLE
-from sys import exit
+# from sys import exit
+from signal import SIGTERM
+from os import getpid, kill
 from os.path import join
 from tempfile import gettempdir
 from shutil import copyfile
@@ -37,7 +39,9 @@ def check_update() -> None:
         cwd=root_dir,
         creationflags=CREATE_NEW_CONSOLE
     )
-    exit()
+    # exit()
+
+    kill(getpid(), SIGTERM)
     
 if __name__ == '__main__':
     check_update()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from codecs import open as codecs_open
 
 setup(
     name="dgupdater",
-    version="1.1.4",
+    version="1.1.5",
     author="DarkGlance",
     author_email="darkglance.developer@gmail.com",
     description="A NO/LOW Code CLI based auto updation assistant tool for python applications",


### PR DESCRIPTION
The updater executable was previously named `update.exe` in the `.dgupdaterignore` file, which was incorrect. It has been renamed to `dgupdaterupdate.exe` to match the actual binary file name.

Additionally, the application exit process during an update has been improved. Instead of using `sys.exit()`, which can be problematic in some environments, the application now sends a `SIGTERM` signal to its own process ID (`os.kill(os.getpid(), SIGTERM)`). This provides a more reliable and graceful shutdown mechanism when launching the self-updater.

## Summary by Sourcery

Correct the updater executable name and improve the exit mechanism using SIGTERM, and update the package version

Bug Fixes:
- Fix updater executable name in .dgupdaterignore and copy step to match actual binary

Enhancements:
- Use SIGTERM via os.kill for a more reliable shutdown instead of sys.exit in the self-updater

Build:
- Bump dgupdater version to 1.1.5