### PR TITLE
fix(version): handle initial version placeholder in config

### DIFF
--- a/dgupdater/cli_commands/commit/func/validate_version.py
+++ b/dgupdater/cli_commands/commit/func/validate_version.py
@@ -24,7 +24,7 @@ def get_version() -> list[int]:
     with open('dgupdaterconf.json', 'r') as f:
         version: str = load(f)['version']
 
-        if version == "Version will be updated after publishing the changes":
+        if version == "Version will be updated after publishing the changes.":
             return [0, 0, 0]
 
         try:

--- a/dgupdater/cli_commands/commit/func/validate_version.py
+++ b/dgupdater/cli_commands/commit/func/validate_version.py
@@ -24,7 +24,13 @@ def get_version() -> list[int]:
     with open('dgupdaterconf.json', 'r') as f:
         version: str = load(f)['version']
 
-        version = [int(x) for x in version.split(".")]
+        if version == "Version will be updated after publishing the changes":
+            return [0, 0, 0]
+
+        try:
+            version = [int(x) for x in version.split(".")]
+        except ValueError:
+            raise ValueError("dgupdaterconf.json file seems to be corrupted. Try 'dgupdater init' again.")
 
         if len(version) != 3:
             raise ValueError("dgupdaterconf.json file seems to be corrupted. Try 'dgupdater init' again.")

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from codecs import open as codecs_open
 
 setup(
     name="dgupdater",
-    version="1.2.0",
+    version="1.2.1",
     author="DarkGlance",
     author_email="darkglance.developer@gmail.com",
     maintainer="DarkGlance",


### PR DESCRIPTION
The `dgupdaterconf.json` file is initialized with a placeholder string for the version. The version validation logic did not account for this, causing a `ValueError` on first run or after initialization.

This change modifies the `get_version` function to correctly parse the placeholder string, preventing the application from crashing. It also improves error handling for corrupted version strings. Additionally, the package version has been bumped to reflect this fix.

## Summary by Sourcery

Handle placeholder version in dgupdaterconf.json to avoid crashes, add error handling for corrupted version entries, and bump package version.

Bug Fixes:
- Return default version [0, 0, 0] when the placeholder string is encountered in config
- Raise a clear error message when the version string is malformed in dgupdaterconf.json

Build:
- Bump package version to 1.2.1